### PR TITLE
Custom cwd

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,14 @@ var config = module.exports = {};
  * in the local project then in the
  * user's home directory.
  *
- * @param   {String}
+ * ```
+ * var filepath = config.find('.jshintrc');
+ * ```
+ *
+ * @param   {String} `filepath` Filepath to find
+ * @param   {Object} `options` Additional options to use when finding a file.
  * @returns {String} filepath to config file
+ * @api public
  */
 
 config.find = function(filepath, options) {
@@ -66,11 +72,14 @@ config.find = function(filepath, options) {
 /**
  * Parses JSON or YAML
  *
- * @param   {String} filename The name of the file to parse
- * @param   {Object} options {parse:'json'} or {parse:'yaml'}
+ * ```
+ * var obj = config.load('.jshintrc', {parse: 'yaml'});
+ * ```
  *
+ * @param   {String} `filename` The name of the file to parse
+ * @param   {Object} `options` {parse:'json'} or {parse:'yaml'}
  * @return  {Object}
- * @api Public
+ * @api public
  */
 
 config.load = function(filename, options) {
@@ -92,12 +101,11 @@ config.load = function(filename, options) {
  * Searches for a config file in the
  * specified npm module.
  *
- * @param   {String} name       Name of npm module to search
- * @param   {[type]} configFile package.json is the default
- * @param   {[type]} options    Parse options. See config.load
- *
+ * @param   {String} `name`       Name of npm module to search
+ * @param   {String} `configFile` package.json is the default
+ * @param   {Object} `options`    Parse options. See config.load
  * @returns {object} config object
- * @api Public
+ * @api public
  */
 
 config.npmLoad = function(name, configFile, options) {

--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ const env    = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFI
 
 // Path variables
 const home   = path.resolve.bind(path, env, '');
-const local  = path.resolve.bind(path, cwd, '');
-const npm    = path.resolve.bind(path, cwd, 'node_modules');
+const defLocal  = path.resolve.bind(path, cwd, '');
+const defNpm    = path.resolve.bind(path, cwd, 'node_modules');
 
 
 /**
@@ -39,8 +39,19 @@ var config = module.exports = {};
  * @returns {String} filepath to config file
  */
 
-config.find = function(filepath) {
+config.find = function(filepath, options) {
+  if (typeof filepath === 'object') {
+    options = filepath;
+    filepath = null;
+  }
+  var opts = options || {};
+
   var filename = path.basename(filepath);
+  var local = defLocal;
+
+  if (typeof opts.cwd !== 'undefined') {
+    local = path.resolve.bind(path, opts.cwd, '');
+  }
 
   if(file.findFile(local(filepath || 'package.json')) !== null) {
     return file.findFile(local(filepath || 'package.json'));
@@ -90,7 +101,16 @@ config.load = function(filename, options) {
  */
 
 config.npmLoad = function(name, configFile, options) {
+  if (typeof configFile === 'object') {
+    options = configFile;
+    configFile = null;
+  }
   var opts = _.extend({parse: 'json'}, options);
+  var npm = defNpm;
+  if (typeof opts.cwd !== 'undefined') {
+    npm = path.resolve.bind(path, opts.cwd, 'node_modules');
+  }
+
   configFile = configFile || 'package.json';
   var config = file.findFile(npm(name), configFile);
 

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ describe('local config:', function () {
 
   it('should return null when no config file is found', function () {
     var actual = config.load('test/fixtures/.nothingrc.yml');
-    expect(actual).to.eql(null);
+    expect(actual == null).to.be.ok;
   });
 });
 
@@ -35,6 +35,7 @@ describe('npm config:', function () {
         "curly": true,
         "eqeqeq": true,
         "eqnull": true,
+        "esnext": true,
         "immed": true,
         "latedef": true,
         "newcap": true,

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 const expect = require('chai').expect;
+const path = require('path');
 const file = require('fs-utils');
 const config = require('../');
 
@@ -24,6 +25,33 @@ describe('local config:', function () {
     var actual = config.load('test/fixtures/.nothingrc.yml');
     expect(actual == null).to.be.ok;
   });
+
+  it('should parse and load package.json from a specified cwd', function () {
+    var cwd = path.resolve(path.join(process.cwd(), 'node_modules', 'fs-utils'));
+    var actual = config.load({cwd: cwd});
+    expect(actual.name).to.eql('fs-utils');
+  });
+
+  it('should parse and load the specified config file and return JSON, given a specified cwd.', function () {
+    var cwd = path.resolve(path.join(process.cwd(), 'test', 'fixtures'));
+    var actual = config.load('.configrc', {cwd: cwd});
+    var expected = {name: 'Config', description: 'A JSON config file'};
+    expect(actual).to.eql(expected);
+  });
+
+  it('should parse the specified YAML config file and return JSON, given a specified cwd.', function () {
+    var cwd = path.resolve(path.join(process.cwd(), 'test', 'fixtures'));
+    var actual = config.load('.configrc.yml', {parse: 'yaml', cwd: cwd});
+    var expected = {name: 'Config', description: 'A YAML config file'};
+    expect(actual).to.eql(expected);
+  });
+
+  it('should return null when no config file is found', function () {
+    var cwd = path.resolve(path.join(process.cwd(), 'test', 'fixtures'));
+    var actual = config.load('.nothingrc.yml', {cwd: cwd});
+    expect(actual == null).to.be.ok;
+  });
+
 });
 
 describe('npm config:', function () {
@@ -56,6 +84,40 @@ describe('npm config:', function () {
     it('should parse the specified config file and return JSON.', function () {
       var actual = config.npmLoad('fs-utils', 'bower.json');
       expect(actual.name).to.eql('fs-utils');
+    });
+  });
+
+  describe('when a cwd is specified', function () {
+    it('should parse the specified config file and return JSON.', function () {
+      var cwd = path.resolve(path.join(process.cwd(), 'node_modules', 'fs-utils'));
+      var actual = config.npmLoad('globule', '.jshintrc', {cwd: cwd});
+      var expected = {
+        "curly": true,
+        "eqeqeq": true,
+        "immed": true,
+        "latedef": true,
+        "newcap": true,
+        "noarg": true,
+        "sub": true,
+        "undef": true,
+        "unused": true,
+        "boss": true,
+        "eqnull": true,
+        "node": true
+      };
+      expect(actual).to.eql(expected);
+    });
+
+    it('should parse the specified config file and return JSON.', function () {
+      var cwd = path.resolve(path.join(process.cwd(), 'node_modules', 'fs-utils'));
+      var actual = config.npmLoad('globule', {cwd: cwd});
+      expect(actual.name).to.eql('globule');
+    });
+
+    it('should parse the specified config file and return JSON.', function () {
+      var cwd = path.resolve(path.join(process.cwd(), 'node_modules', 'fs-utils'));
+      var actual = config.npmLoad('js-yaml', 'bower.json', {cwd: cwd});
+      expect(actual.name).to.eql('js-yaml');
     });
   });
 });


### PR DESCRIPTION
Allows passing `options` with `cwd` to `load` and `find` to override where `local` and `npm` look for configuration files.

I didn't implement checking for different file extensions and types. I don't think that belongs here.

closes #1